### PR TITLE
[fix] : Fixed the human in the loop issue

### DIFF
--- a/Meta/extractor.py
+++ b/Meta/extractor.py
@@ -20,7 +20,7 @@ class MetadataExtractor:
     def extract_metadata(self, query: str, state: ConversationState | None = None) -> Metadata:
         try:
             logger.info(f"Extracting metadata from query: {query}")
-        
+
             context_hint = ""
             if state:
                 last_tool = state.last_tool_used or ""
@@ -28,46 +28,55 @@ class MetadataExtractor:
                 last_entities = state.context_entities or {}
 
                 context_hint = f"""
-                Previous tool used: {last_tool}
-                Last assistant message: {last_msg}
-                Previously detected entities (if any): {json.dumps(last_entities)}
-                Use this context if the current query is ambiguous or a follow-up.
-                """
+Previous tool used: {last_tool}
+Last assistant message: {last_msg}
+Previously detected entities (if any): {json.dumps(last_entities)}
+Use this context if the current query is ambiguous or a follow-up.
+""".strip()
 
-            system_prompt = f"""
-            You are a metadata extraction assistant.
-            Your job is to extract the following structured fields from a user query:
-            - intents: A list of high-level user goals like 'explain', 'check_eligibility', 'register'
-            - entities: Key entities such as the name of the scheme. If multiple schemes are mentioned, return them as a list.
-            - user_profile: Includes 'user_type' (e.g., 'woman_entrepreneur', 'student') and 'location'. If no location is specified in the query, use "unknown" or "India" as a fallback.
-            - If user_type is not explicitly mentioned, infer it from the context (e.g., if asking about subsidies, default to "entrepreneur").
-            - Always return non-empty user_type and location if possible.
+            # Final user query with context injected
+            contextual_query = f"{context_hint}\n\nCurrent query: {query}" if context_hint else query
 
-            Respond ONLY with the following JSON structure:
-            {{
-                "intents": [...],
-                "entities": {{
-                    "scheme": "..."
-                }},
-                "user_profile": {{
-                    "user_type": "...",
-                    "location": "..."
-                }}
-            }}
+            system_prompt = """
+You are a metadata extraction assistant.
+Your job is to extract the following structured fields from a user query:
+- intents: A list of high-level user goals like 'explain', 'check_eligibility', 'register'
+- entities: Key entities such as the name of the scheme. If multiple schemes are mentioned, return them as a list.
+- user_profile: Includes 'user_type' (e.g., 'woman_entrepreneur', 'student') and 'location'. If no location is specified in the query, use "unknown" or "India" as a fallback.
+- If user_type is not explicitly mentioned, infer it from the context (e.g., if asking about subsidies, default to "entrepreneur").
+- Always return non-empty user_type and location if possible.
 
-            Context:
-            {context_hint}
-            """
+Respond ONLY with the following JSON structure:
+{
+  "intents": [...],
+  "entities": {
+    "scheme": "..."
+  },
+  "user_profile": {
+    "user_type": "...",
+    "location": "..."
+  }
+}
 
-            raw_output = self.llm_client.run_chat(system_prompt, query)
+- Make sure all keys are enclosed in double quotes and properly comma-separated.
+""".strip()
 
-            json_blocks = re.findall(r'```json\s*(\{.*?\})\s*```', raw_output, re.DOTALL)
-            if not json_blocks:
-                json_blocks = re.findall(r'(\{.*\})', raw_output, re.DOTALL)
-            if not json_blocks:
-                raise ValueError("No valid JSON block found in LLM response.")
+            raw_output = self.llm_client.run_chat(system_prompt, contextual_query)
+            logger.info(f"Raw output from LLM:\n{raw_output}")
 
-            metadata_dict = json.loads(json_blocks[-1])
+            # Clean output to strip ```json and ``` wrappers if present
+            def clean_json(raw: str) -> str:
+                raw = re.sub(r"```(?:json)?", "", raw, flags=re.IGNORECASE)
+                raw = raw.replace("```", "").strip()
+                json_match = re.search(r"\{.*\}", raw, re.DOTALL)
+                if not json_match:
+                    raise ValueError("No valid JSON object found in LLM response")
+                return json_match.group(0)
+
+            cleaned_json = clean_json(raw_output)
+            metadata_dict = json.loads(cleaned_json)
+
+            logger.info(f"Metadata extracted:\n{json.dumps(metadata_dict, indent=2)}")
 
             # Normalize location
             raw_loc = metadata_dict["user_profile"].get("location", "").strip().lower()
@@ -92,11 +101,12 @@ class MetadataExtractor:
                 )
             )
 
-            # Update state.context_entities for future memory
+            # Update conversation state for follow-ups
             if state:
                 state.context_entities.update(metadata_dict["entities"])
 
             return metadata
 
         except Exception as e:
+            logger.error(f"Metadata extraction failed: {e}")
             raise UdayamitraException(f"Metadata extraction failed: {e}", sys)

--- a/Servers/pipeline.py
+++ b/Servers/pipeline.py
@@ -8,6 +8,7 @@ from router.planner import Planner
 from router.ToolExecutor import ToolExecutor
 from Logging.logger import logger
 from Exception.exception import UdayamitraException
+from utility.StateManager import StateManager
 
 class PipelineStage(Enum):
     IDLE = auto()
@@ -27,18 +28,16 @@ class Pipeline:
         self.plan: ExecutionPlan | None = None
         self.results = None
 
-        # New: maintain conversation state
+        # Maintain conversation state
         self.conversation_state = state if state is not None else ConversationState()
 
         # Clear previous logs
         open(self.log_file, "w").close()
 
-    # Logging utility
     def log(self, content: str):
         with open(self.log_file, "a") as f:
             f.write(content + "\n\n")
 
-    # Stage transition utility
     def set_stage(self, stage: PipelineStage, message: str):
         self.stage = stage
         self.status_message = message
@@ -51,19 +50,50 @@ class Pipeline:
         self.metadata = extractor.run(self.user_query, state=self.conversation_state)
         self.log(f"Extracted Metadata:\n{self.metadata.model_dump_json(indent=2)}")
 
+        # --- State-aware topic switch detection ---
+        state_manager = StateManager(initial_state=self.conversation_state)
+
+        new_intent = self.metadata.intents[0] if self.metadata.intents else None
+        new_scheme = self.metadata.entities.get("scheme") if self.metadata.entities else None
+
+        last_intent = self.conversation_state.last_intent
+        last_scheme = self.conversation_state.last_scheme_mentioned
+
+        if (new_intent and new_intent != last_intent) or (new_scheme and new_scheme != last_scheme):
+            logger.debug("[Pipeline] Detected topic switch. Resetting partial state.")
+            state_manager.reset_on_topic_switch()
+
     def plan_execution(self):
         self.set_stage(PipelineStage.PLANNING, "Building execution plan...")
         planner = Planner()
         self.plan = planner.build_plan(self.metadata, state=self.conversation_state)
         self.log(f"Execution Plan:\n{self.plan.model_dump_json(indent=2)}")
 
+        # --- Update intent and scheme in state ---
+        state_manager = StateManager(initial_state=self.conversation_state)
+
+        if self.metadata.intents:
+            state_manager.set_last_intent(self.metadata.intents[0])
+
+        if self.metadata.entities and "scheme" in self.metadata.entities:
+            state_manager.set_last_scheme(self.metadata.entities["scheme"])
+
     async def execute_plan(self):
         self.set_stage(PipelineStage.EXECUTION, "Running execution plan with tool executor...")
-        
-        # Updated: pass conversation state
+
         executor = ToolExecutor(conversation_state=self.conversation_state)
         self.results = await executor.run_execution_plan(self.plan, self.metadata)
         self.log(f"Execution Results:\n{json.dumps(self.results, indent=2)}")
+
+        # --- Clear missing inputs for successful tools ---
+        state_manager = StateManager(initial_state=self.conversation_state)
+
+        for task in self.plan.task_list:
+            tool_name = task.tool_name
+            tool_output = self.results.get(tool_name)
+
+            if tool_output and not tool_output.get("error"):
+                state_manager.clear_missing_inputs(tool_name)
 
     async def run(self):
         try:
@@ -74,11 +104,9 @@ class Pipeline:
 
             self.set_stage(PipelineStage.COMPLETED, "Pipeline execution completed successfully.")
 
-            # Save final output
             with open("output.json", "w") as f:
                 json.dump(self.results, f, indent=2)
 
-            # Optionally return conversation state as well
             return {
                 "results": self.results,
                 "conversation_state": self.conversation_state.model_dump()
@@ -89,7 +117,7 @@ class Pipeline:
         except Exception as e:
             self.set_stage(PipelineStage.ERROR, f"Unexpected error: {str(e)}")
 
-        return None  # return None on error
+        return None
 
     def get_status(self):
         return {

--- a/frontend/src/components/PipelineStageOverlay.jsx
+++ b/frontend/src/components/PipelineStageOverlay.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+const stageColors = {
+  IDLE: "bg-gray-400",
+  METADATA_EXTRACTION: "bg-yellow-400",
+  PLANNING: "bg-blue-400",
+  EXECUTION: "bg-indigo-400",
+  COMPLETED: "bg-green-500",
+  ERROR: "bg-red-500",
+};
+
+const PipelineStageOverlay = ({ stage }) => {
+  if (!stage) return null;
+
+  return (
+    <div className="fixed top-4 right-4 z-50 shadow-lg">
+      <div
+        className={`px-4 py-2 rounded-xl text-white font-medium text-sm animate-slide-in ${stageColors[stage] || "bg-gray-500"}`}
+      >
+        🛠️ Current Stage: {stage.replace("_", " ")}
+      </div>
+    </div>
+  );
+};
+
+export default PipelineStageOverlay;

--- a/frontend/src/components/StateVisualizer.jsx
+++ b/frontend/src/components/StateVisualizer.jsx
@@ -1,0 +1,28 @@
+function StateVisualizer({ stage }) {
+  if (!stage || stage === 'COMPLETED') return null;
+
+  const stageColorMap = {
+    METADATA: 'bg-yellow-500',
+    PLANNER: 'bg-blue-500',
+    TOOL_EXECUTION: 'bg-purple-500',
+  };
+
+  const stageLabel = {
+    METADATA: 'Understanding your Query',
+    PLANNER: 'Planning the next steps',
+    TOOL_EXECUTION: 'Running the tools',
+  };
+
+  return (
+    <div className="fixed top-6 right-6 z-50">
+      <div
+        className={`px-4 py-2 rounded-xl text-white shadow-lg animate-pulse transition-all duration-500 ease-in-out
+        ${stageColorMap[stage] || 'bg-gray-600'}`}
+      >
+        {stageLabel[stage] || `Current stage: ${stage}`}
+      </div>
+    </div>
+  );
+}
+
+export default StateVisualizer;

--- a/router/planner.py
+++ b/router/planner.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 from utility.model import Metadata, ExecutionPlan, ToolTask, ConversationState
 from utility.LLM import LLMClient
+from router.ToolExecutor import safe_json_parse
 from Logging.logger import logger
 from Exception.exception import UdayamitraException
 
@@ -68,15 +69,8 @@ Make sure all keys are enclosed in double quotes and properly comma-separated.
             raw_output = self.llm_client.run_chat(system_prompt, user_prompt)
             logger.info(f"Raw output from LLM:\n{raw_output}")
 
-            # Try extracting JSON from output
-            json_blocks = re.findall(r'```json\s*(\{.*?\})\s*```', raw_output, re.DOTALL)
-            if not json_blocks:
-                json_blocks = re.findall(r'(\{.*\})', raw_output, re.DOTALL)
-            if not json_blocks:
-                raise ValueError("No valid JSON block found in LLM response.")
-
-            json_str = json_blocks[-1]
-            plan_dict = json.loads(json_str)
+            # using safe_json_parse to handle invalid JSON
+            plan_dict = safe_json_parse(raw_output)
 
             logger.info(f"Parsed execution plan:\n{json.dumps(plan_dict, indent=2)}")
 

--- a/router/planner.py
+++ b/router/planner.py
@@ -1,19 +1,14 @@
-'''
-planner.py - This module contains the logic for planning tasks.
-
-We aim to build a queue of tasks that need to be executed, each task may or may not be dependent on the output of previous tasks.
-This planner will use LLMs that will identify the tools/MCP servers that will be connected to based on the metadata of the task.
-'''
-
 import json
+import re
 import sys
-from utility.model import Metadata, ExecutionPlan, ToolTask, ConversationState
 from typing import List
+from dotenv import load_dotenv
+
+from utility.model import Metadata, ExecutionPlan, ToolTask, ConversationState
 from utility.LLM import LLMClient
 from Logging.logger import logger
 from Exception.exception import UdayamitraException
 
-from dotenv import load_dotenv
 load_dotenv()
 
 class Planner:
@@ -29,58 +24,76 @@ class Planner:
         try:
             logger.info(f"Building execution plan for metadata: {metadata}")
             context_hint = ""
+
             if state:
                 last_tool = state.last_tool_used or ""
                 last_msg = state.messages[-1].content if state.messages else ""
                 last_entities = state.context_entities or {}
-                print(f"Last entities in state manager: {last_entities}")
-                context_hint = f"""
-                Previous tool used: {last_tool}
-                Last assistant message: {last_msg}
-                Previously detected entities (if any): {json.dumps(last_entities)}
-                Use this context if the current query is ambiguous or a follow-up.
-                """
-            system_prompt = "You are a planning assistant for an AI agent that routes user queries to tools. Your job is to plan a sequence of tasks that will be executed to answer the user's query."
-            print(f"State in planner: {state}")
-            user_prompt = f"""
-            Given this metadata:
-            {metadata.model_dump_json(indent=2)}
-            {"\nConversation history:\n" + context_hint if state else ""}
-            
-            Generate an execution plan that includes:
-            - The type of execution (sequential or parallel)
-                - Sequential: Tasks are executed one after another, specifically if one task depends on the output of another
-                - Parallel: Tasks can be executed simultaneously
-            - The list of tasks that need to be executed
-            {{
-                "execution_type": "sequential",
-                "tasks": [
-                    {{
-                        "tool": "ToolName",
-                        "input": {{ ... }},
-                        "input_from": "OptionalPreviousTool"
-                    }}
-                ]
-            }}
-            Just return the JSON without any commentary.
-            """
 
-            logger.info("Generating execution plan...")
-            plan_dict = self.llm_client.run_json(system_prompt, user_prompt)
-            task_list: List[ToolTask] = []
-            for task in plan_dict["tasks"]:
-                task_list.append(
-                    ToolTask(
-                        tool_name=task["tool"],
-                        input=task["input"],
-                        input_from=task.get("input_from")
-                    )
+                context_hint = f"""
+Conversation History:
+- Previous tool used: {last_tool}
+- Last assistant message: {last_msg}
+- Previously detected entities: {json.dumps(last_entities, indent=2)}
+Use this context if the current query is ambiguous or a follow-up.
+""".strip()
+
+            user_prompt = f"""
+Given the following metadata:
+{metadata.model_dump_json(indent=2)}
+
+{context_hint}
+
+Generate an execution plan that includes:
+- The type of execution (sequential or parallel)
+- The list of tasks that need to be executed in this JSON format:
+
+{{
+  "execution_type": "sequential",
+  "tasks": [
+    {{
+      "tool": "ToolName",
+      "input": {{ ... }},
+      "input_from": "OptionalPreviousTool"
+    }}
+  ]
+}}
+
+Only return a valid JSON object, no explanation.
+Make sure all keys are enclosed in double quotes and properly comma-separated.
+""".strip()
+
+            system_prompt = "You are a planning assistant for an AI agent that routes user queries to tools."
+
+            raw_output = self.llm_client.run_chat(system_prompt, user_prompt)
+            logger.info(f"Raw output from LLM:\n{raw_output}")
+
+            # Try extracting JSON from output
+            json_blocks = re.findall(r'```json\s*(\{.*?\})\s*```', raw_output, re.DOTALL)
+            if not json_blocks:
+                json_blocks = re.findall(r'(\{.*\})', raw_output, re.DOTALL)
+            if not json_blocks:
+                raise ValueError("No valid JSON block found in LLM response.")
+
+            json_str = json_blocks[-1]
+            plan_dict = json.loads(json_str)
+
+            logger.info(f"Parsed execution plan:\n{json.dumps(plan_dict, indent=2)}")
+
+            task_list: List[ToolTask] = [
+                ToolTask(
+                    tool_name=task["tool"],
+                    input=task["input"],
+                    input_from=task.get("input_from")
                 )
+                for task in plan_dict["tasks"]
+            ]
 
             return ExecutionPlan(
                 execution_type=plan_dict["execution_type"],
                 task_list=task_list
             )
+
         except Exception as e:
             logger.error(f"Failed to build execution plan: {e}")
             raise UdayamitraException(f"Planner failed: {e}", sys)

--- a/utility/StateManager.py
+++ b/utility/StateManager.py
@@ -1,12 +1,11 @@
-'''
-StateManager.py - This module defines the state manager for our application.
-'''
-
-from utility.model import ConversationState, Message, ToolMemory, UserProfile
-from typing import Optional, Dict, Any
+from utility.model import (
+    ConversationState, Message, ToolMemory, UserProfile
+)
+from typing import Optional, Dict, Any, List
 from datetime import datetime
 from Logging.logger import logger
 
+MAX_MESSAGE_HISTORY = 7
 
 class StateManager:
     def __init__(self, initial_state: Optional[ConversationState] = None):
@@ -17,6 +16,8 @@ class StateManager:
             self.state = ConversationState()
             logger.debug("[StateManager] Initialized with new conversation state.")
 
+    # Message Handling
+
     def add_message(self, role: str, content: str, tool_used: Optional[str] = None):
         message = Message(
             role=role,
@@ -25,15 +26,24 @@ class StateManager:
             timestamp=datetime.utcnow()
         )
         self.state.messages.append(message)
+        self.trim_messages()
 
-    def set_focus(self, focus: str):
-        self.state.current_focus = focus
+    def trim_messages(self):
+        if len(self.state.messages) > MAX_MESSAGE_HISTORY:
+            self.state.messages = self.state.messages[-MAX_MESSAGE_HISTORY:]
+
+    # Focus / Intent / Context
+
+    def set_last_scheme(self, scheme_name: str):
+        self.state.last_scheme_mentioned = scheme_name
 
     def set_last_tool(self, tool_name: str):
         self.state.last_tool_used = tool_name
 
+    def set_last_intent(self, intent: str):
+        self.state.last_intent = intent
+
     def update_context_entities(self, new_entities: Dict[str, Any]):
-        # Normalize location
         if "location" in new_entities and isinstance(new_entities["location"], dict):
             loc = new_entities["location"]
             new_entities["location"] = ", ".join(
@@ -51,7 +61,9 @@ class StateManager:
         if hasattr(structured_input, 'context_entities') and structured_input.context_entities:
             self.update_context_entities(structured_input.context_entities)
         if hasattr(structured_input, 'scheme_name') and structured_input.scheme_name:
-            self.set_focus(structured_input.scheme_name)
+            self.set_last_scheme(structured_input.scheme_name)
+
+    # Tool Memory
 
     def set_tool_memory(self, tool_name: str, memory_data: Dict[str, Any]):
         self.state.tool_memory[tool_name] = ToolMemory(tool_name=tool_name, data=memory_data)
@@ -59,8 +71,34 @@ class StateManager:
     def get_tool_memory(self, tool_name: str) -> Dict[str, Any]:
         return self.state.tool_memory.get(tool_name, ToolMemory(tool_name=tool_name)).data
 
-    def get_state(self) -> ConversationState:
-        return self.state
+    #  Missing Input Tracking 
+
+    def set_missing_inputs(self, tool_name: str, missing_fields: List[str]):
+        self.state.missing_inputs[tool_name] = missing_fields
+
+    def clear_missing_inputs(self, tool_name: str):
+        if tool_name in self.state.missing_inputs:
+            del self.state.missing_inputs[tool_name]
+
+    def get_missing_inputs(self, tool_name: str) -> List[str]:
+        return self.state.missing_inputs.get(tool_name, [])
+
+    #  Reset Logic 
 
     def reset(self):
+        """Full reset of conversation state"""
         self.state = ConversationState()
+
+    def reset_on_topic_switch(self):
+        """Partial reset for context-sensitive fields"""
+        logger.debug("[StateManager] Partial reset due to topic switch.")
+        self.state.last_scheme_mentioned = None
+        self.state.last_intent = None
+        self.state.last_tool_used = None
+        self.state.context_entities = {}
+        self.state.missing_inputs = {}
+
+    #  State Access
+
+    def get_state(self) -> ConversationState:
+        return self.state

--- a/utility/model.py
+++ b/utility/model.py
@@ -90,8 +90,16 @@ class ToolMemory(BaseModel):
 
 class ConversationState(BaseModel):
     messages: List[Message] = []
-    current_focus: Optional[str] = None  # Scheme name or topic
-    context_entities: Dict[str, Any] = {}  # General info extracted: location, age, gender, etc.
-    last_tool_used: Optional[str] = None
-    tool_memory: Dict[str, ToolMemory] = {}  # Memory per tool
+    
+    # Core memory
     user_profile: Optional[UserProfile] = None
+    context_entities: Dict[str, Any] = {}
+
+    # Tool-related memory
+    last_tool_used: Optional[str] = None
+    last_intent: Optional[str] = None
+    last_scheme_mentioned: Optional[str] = None 
+    tool_memory: Dict[str, ToolMemory] = {}
+
+    # Dynamic state
+    missing_inputs: Dict[str, List[str]] = {}  # tool_name -> list of missing fields


### PR DESCRIPTION
Implemented and integrated a persistent `StateManager` to enable memory-aware, multi-turn conversations in the Udyamitra assistant pipeline.

### What the `StateManager` now supports
- **Message Tracking:** Logs all user, assistant, and tool messages with timestamps.
- **Tool Memory:** Stores the raw + parsed outputs from tools for future reference.
- **Context Entities:** Merges entities from metadata and tool results (e.g., scheme name, user profile).
- **Last Used Tracking:** Remembers `last_tool_used`, `last_intent`, and `last_scheme_mentioned`.
- **Missing Inputs:** Records unresolved fields for follow-up questioning.

### Queries tested using new memory structure

#### 1. _"Tell me about PLI 2.0 scheme"_
- **Result:** Message stored, `last_tool_used` = `SchemeExplainer`, tool memory saved.

#### 2. _"Am I eligible for that scheme?"_
- **Result:** Detected incomplete info → populated `missing_inputs` with required fields.

#### 3. _"I'm a domestic company... [provides missing info]"_
- **Result:** Memory reused to run tool again with filled fields → eligibility confirmed.

### Screenshot
_Conversation history and tool transitions shown in attached screenshot._
<img width="1497" height="1009" alt="image" src="https://github.com/user-attachments/assets/d9b50f99-81c5-48f1-9f98-34b58f3ced5f" />
<img width="610" height="910" alt="image" src="https://github.com/user-attachments/assets/8c4b752f-19cf-4eda-86c1-c06a289c0a46" />
